### PR TITLE
Add max_items value to per_page param description

### DIFF
--- a/lib/grape/pagy.rb
+++ b/lib/grape/pagy.rb
@@ -36,10 +36,11 @@ module Grape
         page = opts.delete(:page) || ::Pagy::DEFAULT[:page]
         page_param = opts[:page_param] || ::Pagy::DEFAULT[:page_param]
         items_param = opts[:items_param] || ::Pagy::DEFAULT[:items_param]
+        max_items = opts[:max_items] || ::Pagy::DEFAULT[:max_items]
 
         @api.route_setting(:pagy_options, opts)
         optional page_param, type: Integer, default: page, desc: 'Page offset to fetch.'
-        optional items_param, type: Integer, default: items, desc: 'Number of items to return per page.'
+        optional items_param, type: Integer, default: items, desc: "Number of items to return per page. Maximum value: #{max_items}"
       end
 
       # @param [Array|ActiveRecord::Relation] collection the collection or relation.


### PR DESCRIPTION
Closes #11

This will automatically add the maximum value for per_page to the description for grape.