### PR TITLE
remove pagy extras

### DIFF
--- a/lib/grape/pagy.rb
+++ b/lib/grape/pagy.rb
@@ -1,5 +1,10 @@
 require 'grape'
 require 'pagy'
+require 'pagy/extras/arel'
+require 'pagy/extras/array'
+require 'pagy/extras/countless'
+require 'pagy/extras/headers'
+require 'pagy/extras/overflow'
 
 module Grape
   module Pagy

--- a/lib/grape/pagy.rb
+++ b/lib/grape/pagy.rb
@@ -1,11 +1,5 @@
 require 'grape'
 require 'pagy'
-require 'pagy/extras/arel'
-require 'pagy/extras/array'
-require 'pagy/extras/countless'
-require 'pagy/extras/headers'
-require 'pagy/extras/items'
-require 'pagy/extras/overflow'
 
 module Grape
   module Pagy


### PR DESCRIPTION
After upgrading to Ruby 3.3.4 and Rails 7.2 I've got

        LoadError: cannot load such file -- pagy/extras/items (LoadError)

When I checked [pagy-extras gem](https://github.com/ddnexus/pagy-extras) I saw it is deprected and integrated into pagy gem, so we can remove these requires now